### PR TITLE
3.md - change the link for API Reference

### DIFF
--- a/labs/coding-101-rest-basics-ga/3.md
+++ b/labs/coding-101-rest-basics-ga/3.md
@@ -49,7 +49,7 @@ the API Reference is one of the most important sources of information.
 
 Study the Ticket API in APIC-EM:
 
-* Open the <a href="http://devnetapic.cisco.com/" target="_blank">APIC-EM Reference Docs</a>. The entire API is presented in scrollable format.
+* Open the <a href="https://developer.cisco.com/site/apic-em/docs/api.html?version=1.6" target="_blank">APIC-EM Reference Docs</a>. Pick the proper version of API. The entire API is presented in scrollable format.
 
     ![](/posts/files/coding-101-rest-basics-ga/assets/images/refguide1.png)
 


### PR DESCRIPTION
Change to updated link https://developer.cisco.com/site/apic-em/docs/api.html?version=1.6 and tell users to pick proper API version
@annegentle 