### PR TITLE
Base64 encoded from username password as ASCII, extra equal sign

### DIFF
--- a/labs/coding-201-parsing-xml/1.md
+++ b/labs/coding-201-parsing-xml/1.md
@@ -33,7 +33,7 @@ To get started, create a simple Python script that sends an HTTP request to the 
 ```
 from urllib.request import Request, urlopen
 req = Request('https://cmxlocationsandbox.cisco.com/api/contextaware/v1/maps/info/DevNetCampus/DevNetBuilding/DevNetZone')
-req.add_header('Authorization', 'Basic bGVhcm5pbmc6bGVhcm5pbmc==')
+req.add_header('Authorization', 'Basic bGVhcm5pbmc6bGVhcm5pbmc=')
 response = urlopen(req)
 responseString = response.read().decode("utf-8")
 print(responseString)


### PR DESCRIPTION
I'm definitely seeing this Basic rather than the one with the extra = sign, but still can't get the Sandbox to give a response with that header. Attempt to fix Issue #82 (but this still doesn't fix it).

```
>>> usernamepass = b64encode(b"learning:learning").decode("ascii")
>>> print(usernamepass)
bGVhcm5pbmc6bGVhcm5pbmc=
```